### PR TITLE
fix fb/google avatar bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,7 @@ class User < ApplicationRecord
     user.email = auth.info.email
     user.password = Devise.friendly_token[0,20]
     user.name = auth.info.name
-    user.avatar = auth.info.image
+    user.remote_avatar_url = auth.info.image
     user.save!
     return user
   end
@@ -105,7 +105,7 @@ class User < ApplicationRecord
     user.email = data.email
     user.password = Devise.friendly_token[0,20]
     user.name = data.name
-    user.avatar = data.image
+    user.remote_avatar_url = data.image
     user.save!
     return user    
   end


### PR DESCRIPTION
根據[這篇](https://stackoverflow.com/questions/19868830/devise-omniauth-carrierwave-doesnt-save-facebook-profile-image/19911119#19911119)修復fb/google新帳號註冊不會自動存入頭像的問題，
在local端用google註冊試過了，可以存入，fb要推上部署才能試，估計是相同的bug。
