### PR TITLE
Feature/user/redirect origin page

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js.erb
+++ b/app/assets/javascripts/ckeditor/config.js.erb
@@ -14,7 +14,7 @@ CKEDITOR.editorConfig = function( config )
 
   /* Filebrowser routes */
   // The location of an external file browser, that should be launched when "Browse Server" button is pressed.
-  config.filebrowserBrowseUrl = "/ckeditor/attachment_files";
+  config.filebrowserBrowseUrl = "";
 
   // The location of an external file browser, that should be launched when "Browse Server" button is pressed in the Flash dialog.
   config.filebrowserFlashBrowseUrl = "/ckeditor/attachment_files";
@@ -35,6 +35,8 @@ CKEDITOR.editorConfig = function( config )
   config.filebrowserUploadUrl = "/ckeditor/attachment_files";
 
   config.allowedContent = true;
+
+  config.linkShowAdvancedTab = false;
 
   config.format_tags = 'p;h1;h2;h3';
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :configure_notifications
-  
+  before_action :store_user_location!, if: :storable_location?
 
   protected
 
@@ -11,5 +11,16 @@ class ApplicationController < ActionController::Base
 
   def configure_notifications
     @notifications = Notification.where(recipient: current_user).unread.order(created_at: :desc)
+  end
+
+  private
+
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr? 
+  end
+
+  def store_user_location!
+    # :user is the scope we are authenticating
+    store_location_for(:user, request.fullpath)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ApplicationRecord
-  after_create -> { NotificationRelayJob.perform_later(self, Notification.unread.count) }
+  after_create -> { NotificationRelayJob.perform_now(self, Notification.unread.count) }
 
   scope :unread, -> { where( :read => false ) }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,8 @@ module Xplorer
 
     # add ckeditor models to the autoload path
     config.autoload_paths += %w(#{config.root}/app/models/ckeditor)
+
+    # action cable
+    config.action_cable.mount_path = '/cable'
   end
 end


### PR DESCRIPTION
- 修正deploy上GCP通知不及時的問題
- 使用者登入後會導回原本那一頁
- 順便關掉編輯器link鈕的瀏覽伺服器按鈕